### PR TITLE
Show listing creators with avatars

### DIFF
--- a/home/views.py
+++ b/home/views.py
@@ -8,5 +8,7 @@ class HomeView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["listings"] = Listing.objects.order_by("id")[:3]
+        context["listings"] = (
+            Listing.objects.select_related("user").order_by("id")[:3]
+        )
         return context

--- a/jobs/views.py
+++ b/jobs/views.py
@@ -26,7 +26,7 @@ class JobListView(ListView):
     def get_queryset(
         self,
     ) -> QuerySet[Job]:  # TODO django filter zamiast ręcznego querowania
-        qs = super().get_queryset().order_by("-created_at")
+        qs = super().get_queryset().select_related("user").order_by("-created_at")
         q = self.request.GET.get("q")
         mode = self.request.GET.get("mode")
         status = self.request.GET.get("status")

--- a/listings/views.py
+++ b/listings/views.py
@@ -20,6 +20,7 @@ class ListingListView(ListView):
         qs = (
             super()
             .get_queryset()
+            .select_related("user")
             .filter(type=Listing.ListingType.TUTOR, is_active=True)
             .order_by("-created_at")
         )
@@ -50,6 +51,7 @@ class MentorListView(ListView):
         qs = (
             super()
             .get_queryset()
+            .select_related("user")
             .filter(type=Listing.ListingType.MENTOR, is_active=True)
             .order_by("-created_at")
         )

--- a/templates/job-list.html
+++ b/templates/job-list.html
@@ -137,21 +137,20 @@
                                             {% endfor %}
                                         </div>
                                     {% endif %}
-                                    {% if user.is_authenticated %}
-                                        <div class="trainer d-flex justify-content-between align-items-center mt-3">
-                                            <div class="trainer-profile d-flex align-items-center">
-                                                <img src="{% static 'img/trainers/trainer-1-2.jpg' %}"
-                                                     class="img-fluid"
-                                                     alt="">
-                                                <a href="/" class="trainer-link">{{ job.user.username }}</a>
-                                            </div>
-                                            <div class="trainer-rank d-flex align-items-center">
-                                                <i class="bi bi-person user-icon"></i>&nbsp;50
-                                                &nbsp;&nbsp;
-                                                <i class="bi bi-heart heart-icon"></i>&nbsp;65
+                                    <div class="trainer d-flex justify-content-between align-items-center mt-3">
+                                        <div class="trainer-profile d-flex align-items-center">
+                                            <img src="{{ job.user.avatar_url }}"
+                                                 class="img-fluid rounded-circle me-2"
+                                                 alt="Avatar for {{ job.user.display_name }}">
+                                            <div>
+                                                <span class="trainer-link d-block">{{ job.user.display_name }}</span>
+                                                <small class="text-muted">{{ job.user.role }}</small>
                                             </div>
                                         </div>
-                                    {% endif %}
+                                        <div class="trainer-rank text-end">
+                                            <small class="text-muted">Posted {{ job.created_at|date:"M j, Y" }}</small>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/templates/listing-tiles.html
+++ b/templates/listing-tiles.html
@@ -26,15 +26,16 @@
                             <p class="description">{{ listing.description|truncatechars:140 }}</p>
                             <div class="trainer d-flex justify-content-between align-items-center">
                                 <div class="trainer-profile d-flex align-items-center">
-                                    <img src="{% static 'img/trainers/trainer-1-2.jpg' %}"
-                                         class="img-fluid"
-                                         alt="">
-                                    <a href="#" class="trainer-link">{{ listing.user.get_full_name|default:listing.user.username }}</a>
+                                    <img src="{{ listing.user.avatar_url }}"
+                                         class="img-fluid rounded-circle me-2"
+                                         alt="Avatar for {{ listing.user.display_name }}">
+                                    <div>
+                                        <span class="trainer-link d-block">{{ listing.user.display_name }}</span>
+                                        <small class="text-muted">{{ listing.user.role }}</small>
+                                    </div>
                                 </div>
-                                <div class="trainer-rank d-flex align-items-center">
-                                    <i class="bi bi-person user-icon"></i>&nbsp;50
-                                    &nbsp;&nbsp;
-                                    <i class="bi bi-heart heart-icon"></i>&nbsp;65
+                                <div class="trainer-rank text-end">
+                                    <small class="text-muted">Posted {{ listing.created_at|date:"M j, Y" }}</small>
                                 </div>
                             </div>
                         </div>

--- a/users/models.py
+++ b/users/models.py
@@ -1,3 +1,5 @@
+from urllib.parse import quote_plus
+
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 
@@ -17,6 +19,23 @@ class Account(AbstractUser):
     @property
     def role(self) -> str:
         return self.get_role_level_display()
+
+    @property
+    def display_name(self) -> str:
+        """Return the most user-friendly name to show for the account."""
+
+        full_name = (self.get_full_name() or "").strip()
+        return full_name or self.username
+
+    @property
+    def avatar_url(self) -> str:
+        """Generate a deterministic avatar URL based on the user's name."""
+
+        name_for_avatar = quote_plus(self.display_name or self.username)
+        return (
+            "https://ui-avatars.com/api/?"
+            f"name={name_for_avatar}&background=random&color=ffffff&size=128"
+        )
 
     @property
     def can_browse(self) -> bool:


### PR DESCRIPTION
## Summary
- display listing and job cards with the actual creator name, role, and avatar instead of a static placeholder
- add helper properties on the user model to provide a friendly display name and deterministic avatar URL
- eager-load listing and job owners in their views to avoid extra queries when rendering cards

## Testing
- python manage.py test *(fails: ModuleNotFoundError: No module named 'crispy_forms')*

------
https://chatgpt.com/codex/tasks/task_e_68de9989bfc88323b450bae13c5c838a